### PR TITLE
remove first build number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/bin/dev-build-release
+++ b/bin/dev-build-release
@@ -28,7 +28,7 @@ function bumpWithBranch(version, build, branch) {
     var minor = vArray[1];
     var feature = bArray[bArray.length - 1];
 
-    return major + '.' + minor + '.' + build + '-' + feature + '.' + build;
+    return major + '.' + minor + '-' + feature + '.' + build;
 }
 
 function bump(version, build) {


### PR DESCRIPTION
If we have the build number before the last dot then we will have to update the package.json manually for every new build when working on a feature branch.
