### PR TITLE
append -feature.build to full version number because it's invalid

### DIFF
--- a/bin/dev-build-release
+++ b/bin/dev-build-release
@@ -21,14 +21,10 @@ function getPkg() {
 }
 
 function bumpWithBranch(version, build, branch) {
-    var vArray = version.split('.');
     var bArray = branch.split('/');
-
-    var major = vArray[0];
-    var minor = vArray[1];
     var feature = bArray[bArray.length - 1];
 
-    return major + '.' + minor + '-' + feature + '.' + build;
+    return version + '-' + feature + '.' + build;
 }
 
 function bump(version, build) {


### PR DESCRIPTION
Got this wrong with the last one. We need to append the -feature.build to the end instead of putting it in the middle. npm gets angry when there are letters in the minor version.
