### PR TITLE
feat: using full branch name

### DIFF
--- a/bin/utils.js
+++ b/bin/utils.js
@@ -4,10 +4,8 @@ var chalk = require('chalk'),
 
 module.exports = {
     bumpWithBranch: function(version, build, branch) {
-        var bArray = branch.split('/');
-        var feature = bArray[bArray.length - 1];
-    
-        return version + '-' + feature + '.' + build;
+        var branchNameCharReplaced = branch.replaceAll('/', '-');
+        return version + '-' + branchNameCharReplaced + '.' + build;
     },
     bump: function(version, build) {
         var vArray = version.split('.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-build-release",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Simple tool to append the build number to the package.json for a development release",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
This changes branch names to include full path branch names. Example branch  `feat/tempFeatureBranch`

Old way:
`tempFeatureBranch`

New way:
`feat-tempFeatureBranch`