### PR TITLE
fix(generate-version-file) add support for gitlab pipeline variables

### DIFF
--- a/bin/generate-version-file
+++ b/bin/generate-version-file
@@ -78,7 +78,7 @@ function getDependencies(package) {
 function extractBuildInfo(jenkinsVariable, gitLabVariable) {
     let value = process.env[jenkinsVariable];
     if (!value || value.length === 0) {
-        value = gitLabVariable;
+        value = process.env[gitLabVariable];
         utils.log("Must be a gitlab build, will use " + gitLabVariable + " variable instead '" + value + "'");
     }
     return value;

--- a/bin/generate-version-file
+++ b/bin/generate-version-file
@@ -75,13 +75,22 @@ function getDependencies(package) {
     return allDependencies;
 }
 
+function extractBuildInfo(jenkinsVariable, gitLabVariable) {
+    let value = jenkinsVariable;
+    if (!value || value.length === 0) {
+        value = gitLabVariable;
+        utils.log("Must be a gitlab build, will use " + gitLabVariable + " variable instead '" + value + "'");
+    }
+    return value;
+}
+
 var versionJson = {
     project: parentPackage.name,
     version: parentPackage.version,
     build: {
-        url: process.env.BUILD_URL ?? process.env.CI_PIPELINE_URL,
-        name: process.env.JOB_NAME ?? process.env.CI_PROJECT_DIR,
-        number: process.env.BUILD_NUMBER ?? process.env.CI_PIPELINE_ID,
+        url: extractBuildInfo(process.env.BUILD_URL, process.env.CI_PIPELINE_URL),
+        name: extractBuildInfo(process.env.JOB_NAME, process.env.CI_PROJECT_DIR),
+        number: extractBuildInfo(process.env.BUILD_NUMBER, process.env.CI_PIPELINE_ID),
         buildTime: getTime(),
         machine: os.hostname()
     },

--- a/bin/generate-version-file
+++ b/bin/generate-version-file
@@ -79,9 +79,9 @@ var versionJson = {
     project: parentPackage.name,
     version: parentPackage.version,
     build: {
-        url: process.env.BUILD_URL,
-        name: process.env.JOB_NAME,
-        number: process.env.BUILD_NUMBER,
+        url: process.env.BUILD_URL ?? process.env.CI_PIPELINE_URL,
+        name: process.env.JOB_NAME ?? process.env.CI_PROJECT_DIR,
+        number: process.env.BUILD_NUMBER ?? process.env.CI_PIPELINE_ID,
         buildTime: getTime(),
         machine: os.hostname()
     },

--- a/bin/generate-version-file
+++ b/bin/generate-version-file
@@ -96,7 +96,7 @@ var versionJson = {
     },
     tools: {
         git: {
-            branch: gitInfo.branch || process.env.BRANCH_NAME,
+            branch: gitInfo.branch || extractBuildInfo('BRANCH_NAME', 'CI_COMMIT_REF_NAME'),
             hash: gitInfo.sha,
             tags: (gitInfo.tag) ? gitInfo.tag : undefined,
             originUrl: getRepoUrl(parentPackage),

--- a/bin/generate-version-file
+++ b/bin/generate-version-file
@@ -76,7 +76,7 @@ function getDependencies(package) {
 }
 
 function extractBuildInfo(jenkinsVariable, gitLabVariable) {
-    let value = jenkinsVariable;
+    let value = process.env[jenkinsVariable];
     if (!value || value.length === 0) {
         value = gitLabVariable;
         utils.log("Must be a gitlab build, will use " + gitLabVariable + " variable instead '" + value + "'");
@@ -88,9 +88,9 @@ var versionJson = {
     project: parentPackage.name,
     version: parentPackage.version,
     build: {
-        url: extractBuildInfo(process.env.BUILD_URL, process.env.CI_PIPELINE_URL),
-        name: extractBuildInfo(process.env.JOB_NAME, process.env.CI_PROJECT_DIR),
-        number: extractBuildInfo(process.env.BUILD_NUMBER, process.env.CI_PIPELINE_ID),
+        url: extractBuildInfo('BUILD_URL', 'CI_PIPELINE_URL'),
+        name: extractBuildInfo('JOB_NAME', 'CI_PROJECT_DIR'),
+        number: extractBuildInfo('BUILD_NUMBER', 'CI_PIPELINE_ID'),
         buildTime: getTime(),
         machine: os.hostname()
     },


### PR DESCRIPTION
Updates build info to try to use gitlab pipeline variables if jenkins variables are not available

